### PR TITLE
Minor fixes to u2fdemo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /pkg/*
 /bin/*
 /src/*
+1
+u2fdemo

--- a/registration.go
+++ b/registration.go
@@ -19,7 +19,7 @@ type Registration struct {
 	// Base64 encoded ASN1 public key
 	PublicKey string
 	// Usage counter
-	Counter uint
+	Counter uint32
 	// Base64 encoded PEM certificate
 	Certificate string
 }
@@ -66,7 +66,7 @@ func (reg *registrationRaw) ToRegistration() *Registration {
 		KeyHandle:   keyHandleString,
 		PublicKey:   publicKeyString,
 		Certificate: certString,
-		Counter:     uint(reg.Counter),
+		Counter:     reg.Counter,
 	}
 
 	return &cleanReg
@@ -96,7 +96,7 @@ func (reg *registrationRaw) FromRegistration(r Registration) error {
 	reg.AttestationCert = cert
 
 	// Counter
-	reg.Counter = uint32(r.Counter)
+	reg.Counter = r.Counter
 
 	return nil
 }

--- a/u2fdemo/main.go
+++ b/u2fdemo/main.go
@@ -23,7 +23,6 @@ var trustedFacets = []string{appID}
 var challenge *u2f.Challenge
 
 var registrations []u2f.Registration
-var counter uint32
 
 func registerRequest(w http.ResponseWriter, r *http.Request) {
 	c, err := u2f.NewChallenge(appID, trustedFacets, registrations)
@@ -59,7 +58,6 @@ func registerResponse(w http.ResponseWriter, r *http.Request) {
 	}
 
 	registrations = append(registrations, *reg)
-	counter = 0
 
 	log.Printf("Registration success: %+v", reg)
 	w.Write([]byte("success"))
@@ -103,9 +101,9 @@ func signResponse(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newCounter, err := challenge.Authenticate(signResp)
+	reg, err := challenge.Authenticate(signResp)
 	if err == nil {
-		log.Printf("newCounter: %d", newCounter)
+		log.Printf("newCounter: %d", reg.Counter)
 		w.Write([]byte("success"))
 		return
 	}
@@ -119,6 +117,9 @@ const indexHTML = `
 <html>
   <head>
     <script src="//code.jquery.com/jquery-1.11.2.min.js"></script>
+
+    <!-- The original u2f-api.js code can be found here:
+    https://github.com/google/u2f-ref-code/blob/master/u2f-gae-demo/war/js/u2f-api.js -->
     <script type="text/javascript" src="https://demo.yubico.com/js/u2f-api.js"></script>
 
   </head>


### PR DESCRIPTION
A few minor fixes to the demo program:

* The value of the counter was not being preserved between authentications because we were modifying a copy of the registration entry rather then the registration entry itself
* Not necessary to convert the registration to raw form during authentication
* The counter is four bytes, golang's uint is at least 4 bytes, so uint32 is most appropriate container
* counter variable in u2fdemo is no longer used, counter is now in the Registration struct
* challenge.Authenticate returns Registration instead of just counter
* Added location of orig u2f-api.js, because why not

 